### PR TITLE
Rest API - Image/File Upload and Display

### DIFF
--- a/src/main/java/org/c4sg/constant/Directory.java
+++ b/src/main/java/org/c4sg/constant/Directory.java
@@ -2,7 +2,7 @@ package org.c4sg.constant;
 
 public enum Directory {
 
-	AVATAR_UPLOAD("avatars"), RESUME_UPLOAD("resumes"), LOGO_UPLOAD("logos");
+	AVATAR_UPLOAD("avatars"), RESUME_UPLOAD("resumes"), LOGO_UPLOAD("logos"), PROJECT_UPLOAD("project_images");
 
 	private String value;
 

--- a/src/main/java/org/c4sg/controller/OrganizationController.java
+++ b/src/main/java/org/c4sg/controller/OrganizationController.java
@@ -28,9 +28,8 @@ public class OrganizationController {
     @Autowired
     private OrganizationService organizationService;
     
-	// Determining if this approach is better that using base64
-	@RequestMapping(value = "/{id}/uploadLogoAsFile", method = RequestMethod.POST)
-	@ApiOperation(value = "Add new upload Logo as Image File")
+	@RequestMapping(value = "/{id}/logo", method = RequestMethod.POST)
+	@ApiOperation(value = "Upload Logo as Image File")
 	public String uploadLogo(@ApiParam(value = "Organization Id", required = true) @PathVariable Integer id,
 			@ApiParam(value = "Image File", required = true) @RequestPart("file") MultipartFile file) {
 
@@ -51,27 +50,7 @@ public class OrganizationController {
 			return "Error saving logo for organization " + id + " : " + e;
 		}
 	}
-
-    @RequestMapping(value = "/{id}/uploadLogo", method = RequestMethod.POST)
-    @ApiOperation(value = "Add new upload Logo")
-    public String uploadLogo(@ApiParam(value = "Organization Id", required = true)
-                             @PathVariable Integer id,
-                             @ApiParam(value = "Request Body", required = true)
-                             @RequestBody String logoFileContent) {
-        try {
-            byte[] imageByte = Base64.decodeBase64(logoFileContent);
-            File directory = new File(LOGO_UPLOAD.getValue());
-            if (!directory.exists()) {
-                directory.mkdir();
-            }
-            File f = new File(organizationService.getLogoUploadPath(id));
-            new FileOutputStream(f).write(imageByte);
-            return "Success";
-        } catch (Exception e) {
-            return "Error saving logo for organization " + id + " : " + e;
-        }
-    }
-
+	
     @CrossOrigin
     @RequestMapping(value = "/all", produces = {"application/json"}, method = RequestMethod.GET)
     @ApiOperation(value = "Find all organizations", notes = "Returns a collection of organizations")
@@ -146,19 +125,20 @@ public class OrganizationController {
     }
 
     @CrossOrigin
-    @RequestMapping(value = "/{id}/getLogo", method = RequestMethod.GET)
+    @RequestMapping(value = "/{id}/logo", method = RequestMethod.GET)
     @ApiOperation(value = "Retrieves organization logo")
     public String retrieveOrganizationLogo(@ApiParam(value = "Organization id to get logo for", required = true)
                                          @PathVariable("id") int id) {
         File logo = new File(organizationService.getLogoUploadPath(id));
         try {
-            FileInputStream fileInputStreamReader = new FileInputStream(logo);
+			FileInputStream fileInputStreamReader = new FileInputStream(logo);
             byte[] bytes = new byte[(int) logo.length()];
             fileInputStreamReader.read(bytes);
+            fileInputStreamReader.close();
             return new String(Base64.encodeBase64(bytes));
         } catch (IOException e) {
             e.printStackTrace();
         return null;
-    }
+        }
     }
 }

--- a/src/main/java/org/c4sg/controller/ProjectController.java
+++ b/src/main/java/org/c4sg/controller/ProjectController.java
@@ -256,7 +256,7 @@ public class ProjectController extends GenericController{
     @CrossOrigin
     @RequestMapping(value = "/{id}/image", method = RequestMethod.GET)
     @ApiOperation(value = "Retrieves project image")
-    public String retrieveImage(@ApiParam(value = "Project id to get logo for", required = true)
+    public String retrieveImage(@ApiParam(value = "Project id to get image for", required = true)
                                          @PathVariable("id") int id) {
         File image = new File(projectService.getImageUploadPath(id));
         try {

--- a/src/main/java/org/c4sg/controller/ProjectController.java
+++ b/src/main/java/org/c4sg/controller/ProjectController.java
@@ -1,6 +1,8 @@
 package org.c4sg.controller;
 
 import io.swagger.annotations.*;
+
+import org.apache.tomcat.util.codec.binary.Base64;
 import org.c4sg.dto.ProjectDTO;
 import org.c4sg.dto.UserDTO;
 import org.c4sg.entity.Project;
@@ -8,14 +10,23 @@ import org.c4sg.exception.NotFoundException;
 import org.c4sg.exception.UserProjectException;
 import org.c4sg.service.ProjectService;
 import org.c4sg.service.UserService;
+import org.c4sg.util.FileUploadUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import javax.validation.Valid;
+
+import static org.c4sg.constant.Directory.PROJECT_UPLOAD;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
 import java.net.URI;
 import java.util.Collections;
 import java.util.HashMap;
@@ -217,6 +228,47 @@ public class ProjectController extends GenericController{
     public List<ProjectDTO> getProjects(@ApiParam(value = "ID of user", required = true)
                                             @PathVariable("id") Integer userId){
         return projectService.getAppliedProjects(userId);
+    }
+    
+    @RequestMapping(value = "/{id}/image", method = RequestMethod.POST)
+   	@ApiOperation(value = "Add new image file for project")
+   	public String uploadImage(@ApiParam(value = "user Id", required = true) @PathVariable("id") Integer id,
+   			@ApiParam(value = "Image File", required = true) @RequestPart("file") MultipartFile file) {
+
+   		String contentType = file.getContentType();
+   		if (!FileUploadUtil.isValidImageFile(contentType)) {
+   			return "Invalid image File! Content Type :-" + contentType;
+   		}
+   		File directory = new File(PROJECT_UPLOAD.getValue());
+   		if (!directory.exists()) {
+   			directory.mkdir();
+   		}
+   		File f = new File(projectService.getImageUploadPath(id));
+   		try (FileOutputStream fos = new FileOutputStream(f)) {
+   			byte[] imageByte = file.getBytes();
+   			fos.write(imageByte);
+   			return "Success";
+   		} catch (Exception e) {
+   			return "Error saving image for Project " + id + " : " + e;
+   		}
+   	}
+    
+    @CrossOrigin
+    @RequestMapping(value = "/{id}/image", method = RequestMethod.GET)
+    @ApiOperation(value = "Retrieves project image")
+    public String retrieveImage(@ApiParam(value = "Project id to get logo for", required = true)
+                                         @PathVariable("id") int id) {
+        File image = new File(projectService.getImageUploadPath(id));
+        try {
+			FileInputStream fileInputStreamReader = new FileInputStream(image);
+            byte[] bytes = new byte[(int) image.length()];
+            fileInputStreamReader.read(bytes);
+            fileInputStreamReader.close();
+            return new String(Base64.encodeBase64(bytes));
+        } catch (IOException e) {
+            e.printStackTrace();
+        return null;
+        }
     }
 }
 

--- a/src/main/java/org/c4sg/controller/UserController.java
+++ b/src/main/java/org/c4sg/controller/UserController.java
@@ -13,11 +13,14 @@ import org.c4sg.util.FileUploadUtil;
 import org.slf4j.LoggerFactory;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.FileSystemResource;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileOutputStream;
+import java.io.IOException;
 import java.util.List;
 import static org.c4sg.constant.Directory.AVATAR_UPLOAD;
 import static org.c4sg.constant.Directory.RESUME_UPLOAD;
@@ -101,7 +104,7 @@ public class UserController {
         return userService.search(userName, firstName, lastName);
     }
     
-    @RequestMapping(value = "/{id}/uploadAvatar", method = RequestMethod.POST)
+    @RequestMapping(value = "/{id}/avatar", method = RequestMethod.POST)
 	@ApiOperation(value = "Add new upload Avatar")
 	public String uploadAvatar(@ApiParam(value = "user Id", required = true) @PathVariable("id") Integer id,
 			@ApiParam(value = "Image File", required = true) @RequestPart("file") MultipartFile file) {
@@ -123,9 +126,26 @@ public class UserController {
 			return "Error saving avatar for User " + id + " : " + e;
 		}
 	}
+    
+    @CrossOrigin
+    @RequestMapping(value = "/{id}/avatar", method = RequestMethod.GET)
+    @ApiOperation(value = "Retrieves user avatar")
+    public String retrieveAvatar(@ApiParam(value = "User id to get avatar for", required = true)
+                                         @PathVariable("id") int id) {
+        File avatar = new File(userService.getAvatarUploadPath(id));
+        try {
+			FileInputStream fileInputStreamReader = new FileInputStream(avatar);
+            byte[] bytes = new byte[(int) avatar.length()];
+            fileInputStreamReader.read(bytes);
+            fileInputStreamReader.close();
+            return new String(Base64.encodeBase64(bytes));
+        } catch (IOException e) {
+            e.printStackTrace();
+        return null;
+        }
+    }
 
-	// Determining if this approach is better that using base64
-	@RequestMapping(value = "/{id}/uploadResume", method = RequestMethod.POST)
+	@RequestMapping(value = "/{id}/resume", method = RequestMethod.POST)
 	@ApiOperation(value = "Add new upload resume")
 	public String uploadResume(@ApiParam(value = "user Id", required = true) @PathVariable("id") Integer id,
 			@ApiParam(value = "Resume File(.pdf)", required = true) @RequestPart("file") MultipartFile file) {
@@ -147,4 +167,20 @@ public class UserController {
 			return "Error saving resume for User " + id + " : " + e;
 		}
 	}
+	
+	
+	
+	@CrossOrigin
+    @RequestMapping(value = "/{id}/resume", method = RequestMethod.GET)
+    @ApiOperation(value = "Retrieves user resume")
+    public FileSystemResource retrieveProjectImage(@ApiParam(value = "User id to get resume for", required = true)
+                                         @PathVariable("id") int id) {
+        File resume = new File(userService.getResumeUploadPath(id));
+        try {
+            return new FileSystemResource(resume);
+        } catch (Exception e) {
+            e.printStackTrace();
+        return null;
+        }
+    }
 }

--- a/src/main/java/org/c4sg/controller/UserController.java
+++ b/src/main/java/org/c4sg/controller/UserController.java
@@ -13,7 +13,9 @@ import org.c4sg.util.FileUploadUtil;
 import org.slf4j.LoggerFactory;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.core.io.FileSystemResource;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -173,12 +175,22 @@ public class UserController {
 	@CrossOrigin
     @RequestMapping(value = "/{id}/resume", method = RequestMethod.GET)
     @ApiOperation(value = "Retrieves user resume")
-    public FileSystemResource retrieveProjectImage(@ApiParam(value = "User id to get resume for", required = true)
+	@ResponseBody
+    public HttpEntity<byte[]> retrieveProjectImage(@ApiParam(value = "User id to get resume for", required = true)
                                          @PathVariable("id") int id) {
         File resume = new File(userService.getResumeUploadPath(id));
         try {
-            return new FileSystemResource(resume);
-        } catch (Exception e) {
+        	FileInputStream fileInputStreamReader = new FileInputStream(resume);
+            byte[] bytes = new byte[(int) resume.length()];
+            fileInputStreamReader.read(bytes);
+            fileInputStreamReader.close();
+            HttpHeaders header = new HttpHeaders();
+            header.setContentType(MediaType.APPLICATION_PDF);
+            header.setContentLength(bytes.length);
+
+            return new HttpEntity<byte[]>(bytes, header);
+            
+        } catch (IOException e) {
             e.printStackTrace();
         return null;
         }

--- a/src/main/java/org/c4sg/service/ProjectService.java
+++ b/src/main/java/org/c4sg/service/ProjectService.java
@@ -23,4 +23,5 @@ public interface ProjectService {
     List<ProjectDTO> getAppliedProjects(Integer userId);
     List<Project> getProjectsByOrganization(Integer orgId);
     List<ProjectDTO> findByUser(Integer userId);
+    String getImageUploadPath(Integer projectId);
 }

--- a/src/main/java/org/c4sg/service/impl/ProjectServiceImpl.java
+++ b/src/main/java/org/c4sg/service/impl/ProjectServiceImpl.java
@@ -2,8 +2,11 @@ package org.c4sg.service.impl;
 
 import static java.util.Objects.nonNull;
 import static java.util.Objects.requireNonNull;
+import static org.c4sg.constant.Directory.PROJECT_UPLOAD;
+import static org.c4sg.constant.Format.IMAGE;
 import static org.c4sg.constant.UserProjectStatus.APPLIED;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -174,4 +177,8 @@ public class ProjectServiceImpl implements ProjectService {
 		}
 		return projectDtos;
 	}
+	
+	public String getImageUploadPath(Integer projectId) {
+        return PROJECT_UPLOAD.getValue() + File.separator + projectId + IMAGE.getValue();
+    }
 }

--- a/src/main/java/org/c4sg/service/impl/UserServiceImpl.java
+++ b/src/main/java/org/c4sg/service/impl/UserServiceImpl.java
@@ -6,7 +6,6 @@ import static org.c4sg.constant.Directory.RESUME_UPLOAD;
 import static org.c4sg.constant.Directory.AVATAR_UPLOAD;
 import static org.c4sg.constant.Format.RESUME;
 import static org.c4sg.constant.Format.IMAGE;
-import org.c4sg.constant.UserRole;
 import org.c4sg.dao.UserDAO;
 import org.c4sg.dao.specification.UserSpecification;
 import org.c4sg.dto.UserDTO;


### PR DESCRIPTION
Intended to address #57.

**Additions**
- Introduces newly functional endpoints based off of existing functionality:
1. `GET /api/organization/{id}/logo` 
2. `POST /api/organization/{id}/logo` 
3. `GET /api/projects/{id}/image` 
4. `POST /api/projects/{id}/image` 
5. `GET /api/users/{id}/avatar` 
6. `POST /api/users/{id}/avatar` 
7. `GET /api/users/{id}/resume` 
8. `POST /api/users/{id}/resume` 

**Changes**
- Endpoints ending with verbal phrases such as `getLogo` and `uploadAvatar` were simplified to nouns to stay consistent with the API and `REST` standard.

**Notes**
- All listed `POST` requests that previously used base64 format strings as parameter values now require `file` type values instead.
- All listed `GET` requests still use base64 encoding.
- Front end story implementations that previously used old endpoints will have to be refactored to use the new endpoints.

