### PR TITLE
Issue #1824 - Introduced separate query for scenarios where category is not being used to filter results.

### DIFF
--- a/src/main/java/org/c4sg/dao/OrganizationDAO.java
+++ b/src/main/java/org/c4sg/dao/OrganizationDAO.java
@@ -53,13 +53,6 @@ public interface OrganizationDAO extends CrudRepository<Organization, Integer> {
                 + " AND (:open is null )"
                 + ")  ORDER BY o.name ASC";
     
-    String FIND_BY_CRITERIA_NO_CATEGORIES = "SELECT DISTINCT o FROM Project p RIGHT OUTER JOIN p.organization o" +
-            " WHERE ((:keyword is null OR LOWER(o.name) LIKE LOWER(CONCAT('%', :keyword, '%'))" +
-                " OR LOWER(o.description) LIKE LOWER(CONCAT('%', :keyword, '%')) OR LOWER(o.country) LIKE LOWER(CONCAT('%', :keyword, '%')))"
-                + " AND (:status is null OR o.status = :status)"              
-                + " AND (:open is null )"
-                + ")  ORDER BY o.name ASC";
-    
     String FIND_BY_CRITERIA_AND_OPEN = "SELECT DISTINCT o FROM Project p JOIN p.organization o" +
             " WHERE ((:keyword is null OR LOWER(o.name) LIKE LOWER(CONCAT('%', :keyword, '%'))" +
                 " OR LOWER(o.description) LIKE LOWER(CONCAT('%', :keyword, '%')) OR LOWER(o.country) LIKE LOWER(CONCAT('%', :keyword, '%')))"

--- a/src/main/java/org/c4sg/dao/OrganizationDAO.java
+++ b/src/main/java/org/c4sg/dao/OrganizationDAO.java
@@ -41,7 +41,22 @@ public interface OrganizationDAO extends CrudRepository<Organization, Integer> {
             " WHERE ((:keyword is null OR LOWER(o.name) LIKE LOWER(CONCAT('%', :keyword, '%'))" +
                 " OR LOWER(o.description) LIKE LOWER(CONCAT('%', :keyword, '%')) OR LOWER(o.country) LIKE LOWER(CONCAT('%', :keyword, '%')))"
                 + " AND (:status is null OR o.status = :status)"
-                + " AND (:categories is null OR o.category in (:categories))"                
+                + " AND (o.category in (:categories))"                
+                + " AND (:open is null )"
+                + ")  ORDER BY o.name ASC";
+    
+    // Issue #1824 - Introduced query instead of performing (:categories) null check on FIND_BY_CRITERIA
+    String FIND_BY_CRITERIA_NO_CATEGORY_FILTER = "SELECT DISTINCT o FROM Project p RIGHT OUTER JOIN p.organization o" +
+            " WHERE ((:keyword is null OR LOWER(o.name) LIKE LOWER(CONCAT('%', :keyword, '%'))" +
+                " OR LOWER(o.description) LIKE LOWER(CONCAT('%', :keyword, '%')) OR LOWER(o.country) LIKE LOWER(CONCAT('%', :keyword, '%')))"
+                + " AND (:status is null OR o.status = :status)"             
+                + " AND (:open is null )"
+                + ")  ORDER BY o.name ASC";
+    
+    String FIND_BY_CRITERIA_NO_CATEGORIES = "SELECT DISTINCT o FROM Project p RIGHT OUTER JOIN p.organization o" +
+            " WHERE ((:keyword is null OR LOWER(o.name) LIKE LOWER(CONCAT('%', :keyword, '%'))" +
+                " OR LOWER(o.description) LIKE LOWER(CONCAT('%', :keyword, '%')) OR LOWER(o.country) LIKE LOWER(CONCAT('%', :keyword, '%')))"
+                + " AND (:status is null OR o.status = :status)"              
                 + " AND (:open is null )"
                 + ")  ORDER BY o.name ASC";
     
@@ -93,6 +108,10 @@ public interface OrganizationDAO extends CrudRepository<Organization, Integer> {
     Page<Organization> findByCriteria(@Param("keyword") String keyWord, @Param("open") Boolean open
     		, @Param("status") String status, @Param("categories") List<String> categories,Pageable pageable);
     
+    @Query(FIND_BY_CRITERIA_NO_CATEGORY_FILTER)
+    Page<Organization> findByCriteriaNoCategoryFilter(@Param("keyword") String keyWord, @Param("open") Boolean open
+    		, @Param("status") String status, Pageable pageable);
+    
     @Query(FIND_BY_CRITERIA_AND_OPEN)
     Page<Organization> findByCriteriaAndOpen(@Param("keyword") String keyWord, @Param("open") Boolean open
     		, @Param("status") String status, @Param("categories") List<String> categories, Pageable pageable);
@@ -108,6 +127,11 @@ public interface OrganizationDAO extends CrudRepository<Organization, Integer> {
     @Query(FIND_BY_CRITERIA)
     List<Organization> findByCriteria(@Param("keyword") String keyWord, @Param("open") Boolean open
     		, @Param("status") String status, @Param("categories") List<String> categories);
+    
+    @Query(FIND_BY_CRITERIA_NO_CATEGORY_FILTER)
+    List<Organization> findByCriteriaNoCategoryFilter(@Param("keyword") String keyWord, @Param("open") Boolean open
+    		, @Param("status") String status);
+    
     
     @Query(FIND_BY_CRITERIA_AND_OPEN)
     List<Organization> findByCriteriaAndOpen(@Param("keyword") String keyWord, @Param("open") Boolean open

--- a/src/main/java/org/c4sg/service/impl/OrganizationServiceImpl.java
+++ b/src/main/java/org/c4sg/service/impl/OrganizationServiceImpl.java
@@ -92,8 +92,10 @@ public class OrganizationServiceImpl implements OrganizationService {
 	    		if(open != null){
 	    			organizations = organizationDAO.findByCriteriaAndCountriesAndOpen(keyWord, countries, open, status, categories);
 	    		}
-	    		else{    			
-	    			organizations = organizationDAO.findByCriteriaAndCountries(keyWord, countries, open, status, categories);
+	    		else{   
+	    			if(categories != null) {
+	    				organizations = organizationDAO.findByCriteriaAndCountries(keyWord, countries, open, status, categories);
+	    			}
 	    		}	
 	    		
 	        }
@@ -101,8 +103,13 @@ public class OrganizationServiceImpl implements OrganizationService {
 	    		if(open != null){
 	    			organizations = organizationDAO.findByCriteriaAndOpen(keyWord, open, status, categories);
 	    		}
-	    		else{    			
-	    			organizations = organizationDAO.findByCriteria(keyWord, open, status, categories);
+	    		else{
+	    			// Issue #1824 - Introduced separate query for scenarios where category is not being used to filter results
+	    			if(categories != null) {
+	    				organizations = organizationDAO.findByCriteria(keyWord, open, status, categories);
+	    			}else {
+	    				organizations = organizationDAO.findByCriteriaNoCategoryFilter(keyWord, open, status);
+	    			}
 	    		}    		
 	    	}
 	    	organizationPages=new PageImpl<Organization>(organizations);
@@ -121,8 +128,13 @@ public class OrganizationServiceImpl implements OrganizationService {
 	    		if(open != null){
 	    			organizationPages = organizationDAO.findByCriteriaAndOpen(keyWord, open, status, categories,pageable);
 	    		}
-	    		else{    			
-	    			organizationPages = organizationDAO.findByCriteria(keyWord, open, status, categories,pageable);
+	    		else{
+	    			// Issue #1824 - Introduced separate query for scenarios where category is not being used to filter results
+	    			if(categories != null) {
+	    				organizationPages = organizationDAO.findByCriteria(keyWord, open, status, categories,pageable);
+	    			}else {
+	    				organizationPages = organizationDAO.findByCriteriaNoCategoryFilter(keyWord, open, status, pageable); 
+	    			}
 	    		}    		
 	    	}    		
     	}


### PR DESCRIPTION
When more than one category was selected for organization search, a SQL error was being encountered because OrganizationDAO.FIND_BY_CRITERIA was doing a null check on :categories which for this scenario comes out as a list (?,?,?). It needed to be enclosed in brackets as (:categories) but the operation IS NULL cannot be performed on more than 1 column. 

My approach was to introduce a separate query which omitted category in the where clause instead of using is null (for the scenario where the user does not provide any category filter options). 